### PR TITLE
Bump to 1.0.0, add documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0] - 2022-03-22
+
+Initial release
+
+[unreleased]: https://github.com/karavel-io/platform-component-ingress-nginx/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/karavel-io/platform-component-ingress-nginx/releases/tag/1.0.0

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx
 description: NGINX Ingress Controller component for Karavel
 type: application
-version: 0.1.0-SNAPSHOT
+version: 1.0.0
 appVersion: 0.49.3
 maintainers:
   - name: MatteoJoliveau
@@ -10,8 +10,8 @@ maintainers:
 
 home: https://github.com/kubernetes/ingress-nginx
 sources:
-- https://github.com/kubernetes/ingress-nginx
-- https://github.com/karavel-io/platform
+  - https://github.com/kubernetes/ingress-nginx
+  - https://github.com/karavel-io/platform
 
 annotations:
   prometheus.enable: prometheus

--- a/docs/1.0.0/configuration.md
+++ b/docs/1.0.0/configuration.md
@@ -6,6 +6,6 @@ component "ingress-nginx" {
 
   # Params default values
 
-  hello = "world"
+  defaultIngress = true # optional, set to false if you want another ingress as default
 }
 ```


### PR DESCRIPTION
Is `defaultIngress` supposed to be documented? I did it, but I can take it out if we don't want it there.

### Contribution checklist

- [x] I have read the [Contribution Guide](../CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://github.com/karavel-io/community/blob/main/CODE_OF_CONDUCT.md) and I accept to follow it in all your interactions with the project
- [x] I have added the relevant entries to the [CHANGELOG](../CHANGELOG.md) in the `Unreleased` section